### PR TITLE
RN v 47 - breaking change fix: remove unused registration of JS modules

### DIFF
--- a/android/src/main/java/com/reactlibrary/securekeystore/RNSecureKeyStorePackage.java
+++ b/android/src/main/java/com/reactlibrary/securekeystore/RNSecureKeyStorePackage.java
@@ -14,17 +14,11 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-import com.facebook.react.bridge.JavaScriptModule;
 
 public class RNSecureKeyStorePackage implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     return Arrays.<NativeModule>asList(new RNSecureKeyStoreModule(reactContext));
-  }
-
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
   }
 
   @Override


### PR DESCRIPTION
Fix for breaking change - remove unused registration of JS modules introduced in react-native release 0.47.0