### PR TITLE
Fixing podspec to match s.source_files

### DIFF
--- a/ios/RNSecureKeyStore.podspec
+++ b/ios/RNSecureKeyStore.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/RNSecureKeyStore.git", :tag => "master" }
-  s.source_files  = "*.{h,m}"
+  s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
 
 

--- a/ios/RNSecureKeyStore.podspec
+++ b/ios/RNSecureKeyStore.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/RNSecureKeyStore.git", :tag => "master" }
-  s.source_files  = "RNSecureKeyStore/**/*.{h,m}"
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
 
 


### PR DESCRIPTION
There is no RNSecureKeyStore in the root directory hence when pod is installed, it wouldn't be able to find *h *m file.