### PR TITLE
replace deprecated 'compile' with 'implementation' in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
PR to fix this warning during android build:

Configure project :react-native-secure-key-store
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018.

'compile' will become obsolete very soon.