### PR TITLE
Cleanup podspec, and add required homepage field

### DIFF
--- a/ios/RNSecureKeyStore.podspec
+++ b/ios/RNSecureKeyStore.podspec
@@ -2,17 +2,15 @@
 Pod::Spec.new do |s|
   s.name         = "RNSecureKeyStore"
   s.version      = "1.0.0"
-  s.summary      = "RNSecureKeyStore"
-  s.description  = <<-DESC
-                  RNSecureKeyStore
-                   DESC
-  s.homepage     = ""
+  s.summary      = "A package for secure storage on android and ios"
+  s.description  = "A package for secure storage on android and ios. Stores using the keystore on Android devices, and the keychain on iOS devices."
+  s.homepage     = "https://github.com/pradeep1991singh/react-native-secure-key-store#readme"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
+  s.author       = { "author" => "pradeep1991singh" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNSecureKeyStore.git", :tag => "master" }
-  s.source_files  = "ios/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/pradeep1991singh/react-native-secure-key-store", :tag => "master" }
+  s.source_files = "**/*.{h,m}"
   s.requires_arc = true
 
 


### PR DESCRIPTION
Homepage field in the podspec is required, and the empty string there prevents the pod from being installed in newer versions of Cocoapods.