### PR TITLE
Reference correct filename in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ react-native link react-native-secure-key-store
 
 #### Android
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
+1. Open up `android/app/src/main/java/[...]/MainApplication.java`
   - Add `import com.reactlibrary.securekeystore.RNSecureKeyStorePackage;` to the imports at the top of the file
   - Add `new RNSecureKeyStorePackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:


### PR DESCRIPTION
This is just a minor fix to the instructions:
As we can see from the `example` in this repository, the additions for android have to made in the `MainApplication.java` and not the `MainActivity.java`.

> Fix wrong filename in android instructions: Change `MainActivity` to `MainApplication`.