### PR TITLE
updates android sdk to 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,12 +13,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
This updates the android SDK to 28 to prevent the following error when compiling for release target (using RN 0.59):

`error: resource android:attr/dialogCornerRadius`

