### PR TITLE
fix warning of requiring main queue setup

### DIFF
--- a/ios/RNSecureKeyStore.m
+++ b/ios/RNSecureKeyStore.m
@@ -29,6 +29,11 @@
     return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 RCT_EXPORT_MODULE()
 
 static NSString *serviceName = @"RNSecureKeyStoreKeyChain";


### PR DESCRIPTION
Fix the issue: https://github.com/pradeep1991singh/react-native-secure-key-store/issues/48