### PR TITLE
Change "compile" into "implementation" to avoid warning in Android.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Removes a warning that says
>INFO: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
that appears when running a project with this lib on Android.