### PR TITLE
fix: Fix an issue to generating keys in some android devices in FA an AR

### DIFF
--- a/android/src/main/java/com/reactlibrary/securekeystore/RNSecureKeyStoreModule.java
+++ b/android/src/main/java/com/reactlibrary/securekeystore/RNSecureKeyStoreModule.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.os.Build;
 import android.security.KeyPairGeneratorSpec;
 import android.util.Log;
+import java.util.Locale;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -65,6 +66,8 @@ public class RNSecureKeyStoreModule extends ReactContextBaseJavaModule {
   }
 
   private PublicKey getOrCreatePublicKey(String alias) throws GeneralSecurityException, IOException {
+    Locale currentLocale = Locale.getDefault();
+    Locale.setDefault(Locale.ENGLISH);
     KeyStore keyStore = KeyStore.getInstance(getKeyStore());
     keyStore.load(null);
 
@@ -86,6 +89,7 @@ public class RNSecureKeyStoreModule extends ReactContextBaseJavaModule {
       generator.initialize(spec);
       generator.generateKeyPair();
 
+      Locale.setDefault(currentLocale);
       Log.i(Constants.TAG, "created new asymmetric keys for alias");
     }
 


### PR DESCRIPTION
Hi,

I found and an issue that in some older devices if the device's language is Arabic or Persian the module can not create Keys from KeyStore.
I debugged the code and found that the error was in KeyPairGenerator android class and the message was " Can not parse date...." , so I try to change the locale to EN just before creating the keypair and revert the locale to previous locale and after that code works great. I think the error was happened inner in  android or java classes.
