### PR TITLE
Allow consuming apps to set android build settings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,8 @@
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
     // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -18,12 +22,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Addresses issue #78 

This "safeExtGet" pattern can be seen in many popular RN libraries, for example:
https://github.com/react-native-community/lottie-react-native/blob/master/src/android/build.gradle
https://github.com/react-native-community/react-native-camera/blob/master/android/build.gradle

This should allow consuming apps to set the build settings, while also being a minimal change.