### PR TITLE
Made "getPlainText" a public method for use in native code

### DIFF
--- a/android/src/main/java/com/reactlibrary/securekeystore/RNSecureKeyStoreModule.java
+++ b/android/src/main/java/com/reactlibrary/securekeystore/RNSecureKeyStoreModule.java
@@ -194,7 +194,7 @@ public class RNSecureKeyStoreModule extends ReactContextBaseJavaModule {
     return new SecretKeySpec(decryptRsaCipherText(getPrivateKey(alias), cipherTextBytes), Constants.AES_ALGORITHM);
   }
 
-  private String getPlainText(String alias) throws GeneralSecurityException, IOException {
+  public String getPlainText(String alias) throws GeneralSecurityException, IOException {
     SecretKey secretKey = getSymmetricKey(alias);
     byte[] cipherTextBytes = Storage.readValues(getContext(), Constants.SKS_DATA_FILENAME + alias);
     return new String(decryptAesCipherText(secretKey, cipherTextBytes), "UTF-8");


### PR DESCRIPTION
Currently, there is no easy way to access a secure token from the native code of an app. However, there are instances where this may be useful.

This PR makes the `getPlainText` method public so that we're able to use it in Java native interop code:

```java
public class GitModule extends ReactContextBaseJavaModule {
    private static ReactApplicationContext reactContext;

    GitModule(ReactApplicationContext context) {
        super(context);
        reactContext = context;
    }

    @ReactMethod
    public void clone(
        String uri,
        String path,
        Promise promise
    ) {

        RNSecureKeyStoreModule keyStoreModule = new RNSecureKeyStoreModule(reactContext);

        String ghToken = "";
        try {
            ghToken = keyStoreModule.getPlainText("ghToken");
        } catch (Throwable e) {
            e.printStackTrace();
            promise.reject(e);
        }
    }
}
```

This would be the answered question for #35 